### PR TITLE
Animate battle sprites and show winner banner

### DIFF
--- a/battle.css
+++ b/battle.css
@@ -13,7 +13,7 @@ body {
 
 #battle {
   width: 600px;
-  height: 650px;
+  height: 560px;
   position: relative;
 }
 
@@ -33,8 +33,17 @@ body {
   transition: transform 0.3s ease;
 }
 
-#player { bottom: 30px; left: 40px; }
-#enemy { top: 30px; right: 40px; }
+#player {
+  bottom: 30px;
+  left: 40px;
+  animation: slideInLeft 1s ease-out forwards;
+}
+
+#enemy {
+  top: 30px;
+  right: 40px;
+  animation: slideInRight 1s ease-out forwards;
+}
 
 .name-hp-box {
   background: rgba(0, 0, 0, 0.20);
@@ -49,6 +58,9 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.3);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   margin-bottom: 6px;
+  opacity: 0;
+  animation: fadeIn 0.5s ease forwards;
+  animation-delay: 1s;
 }
 
 .hp-bar {
@@ -76,19 +88,28 @@ img.fish-sprite {
   margin-top: 8px;
 }
 
-.textbox {
-  background: rgba(0, 0, 0, 0.20);
+.winner-banner {
+  position: absolute;
+  top: -60px;
+  left: 50%;
+  transform: translateX(-50%);
   color: #ffffff;
-  padding: 10px;
-  text-align: center;
-  font-size: 18px;
-  line-height: 1.6em;
-  margin: 15px;
-  border-radius: 8px;
-  backdrop-filter: blur(4px) saturate(110%);
-  -webkit-backdrop-filter: blur(4px) saturate(110%);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+  text-shadow: 0 2px 4px rgba(0,0,0,0.5);
+}
+
+@keyframes slideInLeft {
+  0% { transform: translateX(-300px); opacity: 0; }
+  100% { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes slideInRight {
+  0% { transform: translateX(300px); opacity: 0; }
+  100% { transform: translateX(0); opacity: 1; }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 #modal {

--- a/battle.html
+++ b/battle.html
@@ -27,8 +27,6 @@
       <img class="fish-sprite" src="images/good.png" alt="Player Fish">
     </div>
   </div>
-
-  <div class="textbox" id="textbox">What will Shellfin do?</div>
 </div>
 
 <div id="modal">

--- a/battle.js
+++ b/battle.js
@@ -8,10 +8,6 @@ function updateHP() {
   document.getElementById('enemy-hp').style.width = enemy.hp + '%';
 }
 
-function setTextbox(text) {
-  document.getElementById('textbox').innerHTML = text;
-}
-
 function animateAttack(attacker) {
   const atkEl = document.getElementById(attacker === player ? 'player' : 'enemy');
   const direction = attacker === player ? '60px' : '-60px';
@@ -20,14 +16,23 @@ function animateAttack(attacker) {
 }
 
 function endBattle(winner) {
-  setTextbox(`${winner.name} wins the battle!`);
+  const winnerEl = document.getElementById(winner === player ? 'player' : 'enemy');
+  const loserEl = document.getElementById(winner === player ? 'enemy' : 'player');
+
+  loserEl.style.display = 'none';
+  const info = winnerEl.querySelector('.name-hp-box');
+  if (info) info.style.display = 'none';
+  const banner = document.createElement('h1');
+  banner.textContent = 'Winner';
+  banner.className = 'winner-banner';
+  winnerEl.appendChild(banner);
+
   setTimeout(() => {
     window.location.href = "index.html";
   }, 3000);
 }
 
 function playerAttack() {
-  setTextbox(`${player.name} used ${player.move.name}!`);
   animateAttack(player);
   setTimeout(() => {
     enemy.hp = Math.max(0, enemy.hp - player.move.power);
@@ -38,7 +43,6 @@ function playerAttack() {
 }
 
 function enemyTurn() {
-  setTextbox(`${enemy.name} used ${enemy.move.name}!`);
   animateAttack(enemy);
   setTimeout(() => {
     player.hp = Math.max(0, player.hp - enemy.move.power);
@@ -87,10 +91,8 @@ function fetchQuestion() {
     setTimeout(() => {
       modal.classList.remove('show');
       if (selected === q.answer) {
-        setTextbox(`Correct! ${player.name} attacks!`);
         setTimeout(playerAttack, 500);
       } else {
-        setTextbox(`Wrong! ${enemy.name} attacks!`);
         setTimeout(enemyTurn, 500);
       }
     }, 2000);


### PR DESCRIPTION
## Summary
- Remove battle overlay text so creatures slide in unobstructed.
- Fade in name/HP boxes after sprites finish sliding to start the fight cleanly.
- Keep winner banner at battle end to highlight the victorious creature.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a37f193a988329bdc0cb60ae86d1c7