### PR TITLE
refactor: enforce universal max width

### DIFF
--- a/battle.css
+++ b/battle.css
@@ -12,7 +12,8 @@ body {
 }
 
 #battle {
-  width: 600px;
+  width: 100%;
+  max-width: var(--max-width);
   height: 560px;
   position: relative;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,8 @@
 /* Shared base styles */
+:root {
+  --max-width: 400px;
+}
+
 body {
   margin: 0;
   font-family: "Arial Rounded MT Bold", Arial, sans-serif;
@@ -35,6 +39,7 @@ body {
   box-sizing: border-box;
   position: relative;
   z-index: 1;
+  max-width: var(--max-width);
 }
 
 /* Home page layout */
@@ -215,13 +220,12 @@ body.login #app {
   justify-content: center;   /* vertical center */
   align-items: center;       /* horizontal center */
   padding: 0;
-  max-width: 400px;
 }
 
 #login-title,
 #login-form {
   width: 100%;
-  max-width: 400px;          /* shared max width column */
+  max-width: var(--max-width);          /* shared max width column */
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- Introduce `--max-width` variable to apply a shared 400px cap across pages
- Remove page-specific width overrides and apply the shared max width to login components
- Cap battle container with the same universal width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e033dbc48329bffa314d58864da3