### PR TITLE
refactor: centralize close button styles

### DIFF
--- a/battle.css
+++ b/battle.css
@@ -227,15 +227,4 @@ img.fish-sprite {
 /* battle.css */
 .creature, .fish-sprite { will-change: transform; }
 
-/* Top X icon */
-#close {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  font-size: 28px;
-  color: white;
-  cursor: pointer;
-  z-index: 2;
-  text-decoration: none;
-}
 

--- a/styles.css
+++ b/styles.css
@@ -169,7 +169,7 @@ body.mission #creature-container {
   letter-spacing: .025cap;
 }
 
-/* Mission page elements */
+/* Shared close button */
 #close {
   position: absolute;
   top: 20px;
@@ -181,6 +181,7 @@ body.mission #creature-container {
   text-decoration: none;
 }
 
+/* Mission page elements */
 #mission {
   padding: 40px;
   width: 100%;


### PR DESCRIPTION
## Summary
- Remove redundant `#close` styles from battle.css
- Host canonical `#close` rule in styles.css for mission and battle pages

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48e8abc8c8329ac0f1449560f83f3