### PR TITLE
Validate login using users.json only

### DIFF
--- a/js/userData.js
+++ b/js/userData.js
@@ -25,22 +25,6 @@ function createUser(username) {
   return true;
 }
 
-async function initUsers() {
-  if (!localStorage.getItem(STORAGE_KEY)) {
-    try {
-      const response = await fetch(USERS_URL);
-      if (response.ok) {
-        const users = await response.json();
-        saveUsers(users);
-      }
-    } catch (err) {
-      console.error("Failed to load users.json", err);
-    }
-  }
-}
-
-initUsers();
-
 function setCurrentUser(username) {
   localStorage.setItem(CURRENT_USER_KEY, username);
 }
@@ -52,14 +36,23 @@ function getCurrentUser() {
   return users[username] || null;
 }
 
-function login(username) {
-  const users = loadUsers();
-  const user = users[username];
-  if (!user) {
+async function login(username) {
+  try {
+    const response = await fetch(USERS_URL);
+    if (!response.ok) {
+      return false;
+    }
+    const users = await response.json();
+    saveUsers(users);
+    if (!users[username]) {
+      return false;
+    }
+    setCurrentUser(username);
+    return true;
+  } catch (err) {
+    console.error("Failed to load users.json", err);
     return false;
   }
-  setCurrentUser(username);
-  return true;
 }
 
 function signOut() {

--- a/pages/index.html
+++ b/pages/index.html
@@ -35,13 +35,13 @@
       const usernameInput = document.getElementById("username");
       const errorMsg = document.getElementById("login-error");
 
-      form.addEventListener("submit", function (e) {
+      form.addEventListener("submit", async function (e) {
         e.preventDefault();
         const username = usernameInput.value.trim();
         usernameInput.classList.remove("input-error");
         errorMsg.textContent = "";
 
-        if (login(username)) {
+        if (await login(username)) {
           window.location.href = this.getAttribute("action");
         } else {
           usernameInput.classList.add("input-error");


### PR DESCRIPTION
## Summary
- always fetch `users.json` when validating login
- drop local user cache initialization

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/userData.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4d5fa788c8329b89beb7dbda55a56