### PR TITLE
Sync user stats with UI

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -60,6 +60,11 @@ body {
   margin-bottom: 6px;
 }
 
+.stats {
+  margin-top: 4px;
+  font-size: 14px;
+}
+
 .hp-bar {
   height: 8px;
   width: 100%;

--- a/css/styles.css
+++ b/css/styles.css
@@ -114,6 +114,11 @@ body.mission #app {
 }
 
 /* Creature */
+#creature-info {
+  text-align: center;
+  color: #fff;
+  margin-bottom: 8px;
+}
 #creature-container {
   width: 180px;
   height: 180px;

--- a/js/battle.js
+++ b/js/battle.js
@@ -8,26 +8,46 @@ const VICTORY_SCREEN_MS = 3000; // Show winner-only screen before redirect (ms)
 const PLAYER_VICTORY_SRC = "../images/creature.png"; // Sprite to use if the PLAYER wins
 
 // ====== State ======
+const user = typeof getCurrentUser === "function" ? getCurrentUser() : null;
+if (!user) {
+  window.location.href = "index.html";
+}
+const defaultCreature = { name: "Shellfin", level: 1, hp: 100, attack: 10 };
+const playerCreature =
+  user && user.creatures && user.creatures.length > 0
+    ? user.creatures[0]
+    : defaultCreature;
 const player = {
-  name: "Shellfin",
-  hp: 100,
-  move: { name: "Fin Swipe", power: 100 },
+  name: playerCreature.name,
+  hp: playerCreature.hp,
+  maxHp: playerCreature.hp,
+  move: { name: "Attack", power: playerCreature.attack },
 };
 const enemy = {
   name: "Octomurk",
   hp: 100,
-  move: { name: "Constrict", power: 100 },
+  maxHp: 100,
+  move: { name: "Constrict", power: 15 },
 };
 let questions = [];
 let isGameOver = false;
 
 // ====== Helpers ======
 function updateHP() {
-  document.getElementById("player-hp").style.width = player.hp + "%";
-  document.getElementById("enemy-hp").style.width = enemy.hp + "%";
+  const pPct = (player.hp / player.maxHp) * 100;
+  const ePct = (enemy.hp / enemy.maxHp) * 100;
+  document.getElementById("player-hp").style.width = pPct + "%";
+  document.getElementById("enemy-hp").style.width = ePct + "%";
+  const pStats = document.getElementById("player-stats");
+  if (pStats)
+    pStats.textContent = `HP: ${player.hp}/${player.maxHp} | ATK: ${player.move.power}`;
+  const eStats = document.getElementById("enemy-stats");
+  if (eStats)
+    eStats.textContent = `HP: ${enemy.hp}/${enemy.maxHp} | ATK: ${enemy.move.power}`;
 }
 
-function animateHP(side /* "player" | "enemy" */, pct, done) {
+function animateHP(side /* "player" | "enemy" */, done) {
+  const data = side === "player" ? player : enemy;
   const fill = document.getElementById(`${side}-hp`);
   if (!fill) {
     done?.();
@@ -35,6 +55,7 @@ function animateHP(side /* "player" | "enemy" */, pct, done) {
   }
   fill.style.transition = `width ${HP_TRANSITION_MS}ms ease`;
   void fill.offsetWidth; // force reflow so transition triggers
+  const pct = (data.hp / data.maxHp) * 100;
   fill.style.width = `${pct}%`;
 
   let finished = false;
@@ -50,6 +71,9 @@ function animateHP(side /* "player" | "enemy" */, pct, done) {
     done?.();
   };
   fill.addEventListener("transitionend", onEnd, { once: true });
+  const statsEl = document.getElementById(`${side}-stats`);
+  if (statsEl)
+    statsEl.textContent = `HP: ${data.hp}/${data.maxHp} | ATK: ${data.move.power}`;
 }
 
 function animateAttack(attacker) {
@@ -210,7 +234,7 @@ function playerAttack() {
   animateAttack(player);
   setTimeout(() => {
     enemy.hp = Math.max(0, enemy.hp - player.move.power);
-    animateHP("enemy", enemy.hp, () => {
+    animateHP("enemy", () => {
       if (enemy.hp <= 0) {
         endBattle(player);
       } else {
@@ -224,7 +248,7 @@ function enemyTurn() {
   animateAttack(enemy);
   setTimeout(() => {
     player.hp = Math.max(0, player.hp - enemy.move.power);
-    animateHP("player", player.hp, () => {
+    animateHP("player", () => {
       if (player.hp <= 0) {
         endBattle(enemy);
       } else {
@@ -303,6 +327,29 @@ async function initGame() {
   } catch (err) {
     console.error("Failed to load questions:", err);
   }
+
+  // Load enemy data
+  try {
+    const res = await fetch("../data/data.json");
+    const data = await res.json();
+    if (Array.isArray(data.enemyCreatures) && data.enemyCreatures.length > 0) {
+      const e =
+        data.enemyCreatures[
+          Math.floor(Math.random() * data.enemyCreatures.length)
+        ];
+      enemy.name = e.name;
+      enemy.hp = e.hp;
+      enemy.maxHp = e.hp;
+      enemy.move.power = e.attack;
+    }
+  } catch (err) {
+    console.error("Failed to load enemy data:", err);
+  }
+
+  const playerNameEl = document.getElementById("player-name");
+  if (playerNameEl) playerNameEl.textContent = player.name;
+  const enemyNameEl = document.getElementById("enemy-name");
+  if (enemyNameEl) enemyNameEl.textContent = enemy.name;
 
   // Initial HP state
   updateHP();

--- a/pages/battle.html
+++ b/pages/battle.html
@@ -16,6 +16,7 @@
           <div class="name-hp-box">
             <div id="enemy-name">Octomurk</div>
             <div class="hp-bar"><div id="enemy-hp" class="hp-fill"></div></div>
+            <div id="enemy-stats" class="stats"></div>
           </div>
           <img class="fish-sprite" src="../images/bad.png" alt="Enemy Fish" />
         </div>
@@ -24,6 +25,7 @@
           <div class="name-hp-box">
             <div id="player-name">Shellfin</div>
             <div class="hp-bar"><div id="player-hp" class="hp-fill"></div></div>
+            <div id="player-stats" class="stats"></div>
           </div>
           <img class="fish-sprite" src="../images/good.png" alt="Player Fish" />
         </div>
@@ -36,6 +38,7 @@
       <div class="modal-content" id="modal-content"></div>
     </div>
 
+    <script src="../js/userData.js"></script>
     <script src="../js/battle.js"></script>
   </body>
 </html>

--- a/pages/home.html
+++ b/pages/home.html
@@ -20,6 +20,7 @@
       </div>
 
       <!-- Creature -->
+      <div id="creature-info"></div>
       <div id="creature-container">
         <img src="../images/creature.png" alt="Creature Sprite" />
       </div>
@@ -48,7 +49,12 @@
         document.getElementById("streak").textContent =
           `🔱 ${user.signInStreak} Day Streak`;
         document.getElementById("seashells").textContent =
-          `🐚 ${user.seashellsEarned} Seashells`;
+          `🐚 ${user.seashells} Seashells`;
+        if (user.creatures && user.creatures.length > 0) {
+          const c = user.creatures[0];
+          const infoEl = document.getElementById("creature-info");
+          if (infoEl) infoEl.textContent = `${c.name} - Lv ${c.level}`;
+        }
         updateCurrentUser({ signInStreak: user.signInStreak + 1 });
       } else {
         window.location.href = "index.html";


### PR DESCRIPTION
## Summary
- show current user's streak and seashells on home page
- display creature name and level above avatar on home page
- load player and enemy stats from data files on battle screen and show HP/attack

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `node --check js/battle.js`

------
https://chatgpt.com/codex/tasks/task_e_68a4dc4d52f083299281f537a0b3c843