### PR TITLE
Use mission data to drive missions and rewards

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -197,9 +197,15 @@ function endBattle(winner) {
     button.textContent = winnerIsPlayer ? "Claim Your Reward" : "Try Again";
     button.addEventListener("click", () => {
       if (winnerIsPlayer) {
-        // Go to rewards / home
+        if (currentMission && user) {
+          const newSeashells =
+            (user.seashells || 0) + (currentMission.reward || 0);
+          updateCurrentUser({ seashells: newSeashells });
+        }
+        sessionStorage.removeItem("currentMission");
         window.location.href = "home.html";
       } else {
+        sessionStorage.removeItem("currentMission");
         // Restart the battle cleanly (rebuilds battlefield we removed)
         window.location.reload();
       }
@@ -331,11 +337,18 @@ async function initGame() {
 
   // Load mission data
   try {
-    const res = await fetch("../data/missions.json");
-    const data = await res.json();
-    if (Array.isArray(data.missions) && data.missions.length > 0) {
-      currentMission =
-        data.missions[Math.floor(Math.random() * data.missions.length)];
+    const stored = sessionStorage.getItem("currentMission");
+    if (stored) {
+      currentMission = JSON.parse(stored);
+    } else {
+      const res = await fetch("../data/missions.json");
+      const data = await res.json();
+      if (Array.isArray(data.missions) && data.missions.length > 0) {
+        currentMission =
+          data.missions[Math.floor(Math.random() * data.missions.length)];
+      }
+    }
+    if (currentMission && currentMission.enemy) {
       const e = currentMission.enemy;
       enemy.name = e.name;
       enemy.hp = e.hp;

--- a/pages/home.html
+++ b/pages/home.html
@@ -61,7 +61,7 @@
         if (user.creatures && user.creatures.length > 0) {
           const c = user.creatures[0];
           const infoEl = document.getElementById("creature-info");
-          if (infoEl) infoEl.textContent = `${c.name} - Lv ${c.level}`;
+          if (infoEl) infoEl.textContent = c.name;
         }
       } else {
         window.location.href = "index.html";

--- a/pages/mission.html
+++ b/pages/mission.html
@@ -16,15 +16,34 @@
 
       <!-- Mission box -->
       <div class="apple-glass" id="mission">
-        <h1>Mission</h1>
-        <p>
-          Octomurk is eating creatures on the reef. Time to show him who’s boss.
-        </p>
-        <div class="rewards">🐚 5 reef rewards</div>
-        <a href="battle.html" class="button">Accept Mission</a>
+        <h1 id="mission-title"></h1>
+        <p id="mission-desc"></p>
+        <div class="rewards" id="mission-reward"></div>
+        <a href="battle.html" class="button" id="accept-mission">Accept Mission</a>
       </div>
     </div>
 
+    <script>
+      document.addEventListener("DOMContentLoaded", async () => {
+        try {
+          const res = await fetch("../data/missions.json");
+          const data = await res.json();
+          if (Array.isArray(data.missions) && data.missions.length > 0) {
+            const mission =
+              data.missions[Math.floor(Math.random() * data.missions.length)];
+            sessionStorage.setItem("currentMission", JSON.stringify(mission));
+            document.getElementById("mission-title").textContent = mission.name;
+            document.getElementById("mission-desc").textContent =
+              mission.description;
+            document.getElementById(
+              "mission-reward",
+            ).textContent = `🐚 ${mission.reward} reef rewards`;
+          }
+        } catch (err) {
+          console.error("Failed to load missions:", err);
+        }
+      });
+    </script>
     <script src="../js/bubbles.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove creature level display on home page
- Load mission title, description, and reward from missions.json
- Apply selected mission's enemy stats to battle and grant seashell reward on victory

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a52410a4548329ab1822728baf635b