### PR TITLE
Fix mission navigation and preserve user data on sign-out

### DIFF
--- a/js/userData.js
+++ b/js/userData.js
@@ -38,16 +38,26 @@ function getCurrentUser() {
 }
 
 async function login(username) {
+  // First, try to load the user from localStorage so progress is preserved
+  let users = loadUsers();
+  if (users[username]) {
+    setCurrentUser(username);
+    return true;
+  }
+
+  // If the user isn't found locally, fall back to the bundled users.json
   try {
     const response = await fetch(USERS_URL);
     if (!response.ok) {
       return false;
     }
-    const users = await response.json();
-    saveUsers(users);
+    const fetched = await response.json();
+    // Merge fetched users with any existing local data without overwriting
+    users = { ...fetched, ...users };
     if (!users[username]) {
       return false;
     }
+    saveUsers(users);
     setCurrentUser(username);
     return true;
   } catch (err) {

--- a/pages/home.html
+++ b/pages/home.html
@@ -27,7 +27,7 @@
 
       <!-- Bottom nav -->
         <div class="apple-glass" id="nav">
-          <a class="nav-item" href="#" id="mission-link">
+          <a class="nav-item" href="mission.html" id="mission-link">
             <span class="emoji">🤿</span>
             <span class="text">Mission</span>
           </a>
@@ -67,37 +67,13 @@
             imgEl.src = c.sprite.normal;
         }
 
-        const missionLink = document.getElementById("mission-link");
-        if (missionLink) {
-          missionLink.addEventListener("click", async (e) => {
-            e.preventDefault();
-            try {
-              const res = await fetch("../data/missions.json");
-              const data = await res.json();
-              if (Array.isArray(data.missions) && data.missions.length > 0) {
-                let missionIndex = 0;
-                if (Array.isArray(user.missionsCompleted)) {
-                  const idx = user.missionsCompleted.findIndex(
-                    (m) => !m.completed,
-                  );
-                  if (idx !== -1) missionIndex = idx;
-                }
-                const mission = data.missions[missionIndex];
-                sessionStorage.setItem(
-                  "currentMission",
-                  JSON.stringify(mission),
-                );
-                sessionStorage.setItem(
-                  "currentMissionIndex",
-                  String(missionIndex),
-                );
-                window.location.href = "battle.html";
-              }
-            } catch (err) {
-              console.error("Failed to load missions:", err);
-            }
-          });
-        }
+      const missionLink = document.getElementById("mission-link");
+      if (missionLink) {
+        missionLink.addEventListener("click", (e) => {
+          e.preventDefault();
+          window.location.href = "mission.html";
+        });
+      }
       } else {
         window.location.href = "index.html";
       }


### PR DESCRIPTION
## Summary
- Avoid wiping local user progress by loading localStorage before fetching bundled users
- Open mission screen from Home before starting battle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a52db53dd883299260572f3367fe5a