### PR TITLE
Revamp battle UI and animated end screen

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -15,15 +15,19 @@ body {
   width: 560px;
   height: 560px;
   position: relative;
+  animation: battleFadeIn 0.6s ease;
 }
 
 .battlefield {
   height: 560px;
   position: relative;
   overflow: hidden;
-  background: transparent;
+  background: rgba(0, 0, 0, 0.2);
   border-radius: 8px;
   color: white;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+  border: 2px solid rgba(255, 255, 255, 0.2);
 }
 
 .creature {
@@ -85,9 +89,14 @@ body {
 img.fish-sprite {
   width: 220px;
   height: auto;
-  transition: transform 0.5s;
+  transition: transform 0.5s, filter 0.5s;
   cursor: pointer;
   margin-top: 8px;
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.5));
+}
+
+img.fish-sprite:hover {
+  transform: scale(1.05);
 }
 
 .intro-overlay {
@@ -259,4 +268,76 @@ img.fish-sprite {
 .creature,
 .fish-sprite {
   will-change: transform;
+}
+
+@keyframes battleFadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.end-screen {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 8px;
+  text-align: center;
+  backdrop-filter: blur(4px);
+  pointer-events: auto;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.end-screen.show {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.end-banner {
+  font-size: 48px;
+  font-weight: 800;
+  color: #fff;
+  text-shadow: 1px 1px 3px #000;
+  margin: 0;
+  line-height: 1.1;
+  transform: translateY(-6px);
+  opacity: 0;
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.end-screen.show .end-banner {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.sprite-wrapper {
+  line-height: 0;
+  transform: scale(0.5);
+  opacity: 0;
+  margin: 20px 0;
+  transition: transform 0.42s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.42s;
+}
+
+.end-screen.show .sprite-wrapper {
+  transform: scale(1);
+  opacity: 1;
+}
+
+.end-sprite {
+  display: block;
+  width: 260px;
+  max-width: 100%;
+  height: auto;
 }

--- a/js/battle.js
+++ b/js/battle.js
@@ -143,63 +143,27 @@ function endBattle(winner) {
 
     if (battleRoot) battleRoot.style.position = "relative";
 
-    // === Centered, shrink-wrapped victory box ===
+    // === Victory/defeat overlay ===
     const victoryBox = document.createElement("div");
-    Object.assign(victoryBox.style, {
-      position: "absolute",
-      left: "50%",
-      top: "50%",
-      transform: "translate(-50%, -50%)",
-      display: "inline-flex",
-      flexDirection: "column",
-      alignItems: "center",
-      justifyContent: "center",
-      gap: "20px",
-      pointerEvents: "auto",
-    });
+    victoryBox.className = "end-screen";
 
-    // Banner (fade/slide in)
+    // Banner
     const banner = document.createElement("h1");
-    banner.textContent = "Winner";
-    Object.assign(banner.style, {
-      fontSize: "48px",
-      fontWeight: "800",
-      color: "#fff",
-      textShadow: "1px 1px 3px #000",
-      margin: "0",
-      lineHeight: "1.1",
-      textAlign: "center",
-      opacity: "0",
-      transform: "translateY(-6px)",
-    });
+    banner.className = "end-banner";
+    banner.textContent = winnerIsPlayer ? "Victory!" : "Defeat";
 
-    // Sprite wrapper (pop scale 0.5 -> 1)
+    // Sprite wrapper
     const spriteWrapper = document.createElement("div");
-    Object.assign(spriteWrapper.style, {
-      display: "inline-block",
-      lineHeight: "0",
-      margin: "80px",
-      padding: "0",
-      transformOrigin: "center center",
-      transform: "scale(0.5)", // start smaller for pop
-      willChange: "transform",
-    });
+    spriteWrapper.className = "sprite-wrapper";
 
     // Winner sprite (player gets special art)
     const originalSprite = winnerEl?.querySelector(".fish-sprite");
     const sprite = document.createElement("img");
+    sprite.className = "end-sprite";
     sprite.alt = winnerIsPlayer ? player.name : enemy.name;
     sprite.src = winnerIsPlayer
       ? PLAYER_VICTORY_SRC
       : originalSprite?.getAttribute("src") || "";
-    Object.assign(sprite.style, {
-      display: "block",
-      width: "260px",
-      maxWidth: "100%",
-      height: "auto",
-      opacity: "0", // fade in
-      willChange: "opacity",
-    });
 
     spriteWrapper.appendChild(sprite);
 
@@ -246,21 +210,9 @@ function endBattle(winner) {
     victoryBox.appendChild(button);
     battleRoot.appendChild(victoryBox);
 
-    // Force reflow, then animate
-    void banner.offsetWidth;
-    void sprite.offsetWidth;
-    void spriteWrapper.offsetWidth;
-
-    banner.style.transition = "opacity 600ms ease, transform 600ms ease";
-    sprite.style.transition = "opacity 800ms ease";
-    spriteWrapper.style.transition =
-      "transform 420ms cubic-bezier(0.22, 1, 0.36, 1)";
-
+    // Trigger reveal animations
     requestAnimationFrame(() => {
-      banner.style.opacity = "1";
-      banner.style.transform = "translateY(0)";
-      sprite.style.opacity = "1";
-      spriteWrapper.style.transform = "scale(1)"; // pop to full size
+      victoryBox.classList.add("show");
     });
   }, LINGER);
 }


### PR DESCRIPTION
## Summary
- Add fade-in and glass-like styling to the battle arena for a cleaner look
- Introduce drop shadows and hover scale to fish sprites for more visual pop
- Replace inline victory code with reusable CSS-driven end screen overlay

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/battle.js`


------
https://chatgpt.com/codex/tasks/task_e_68a62593b3d08329b9e5d0b8a35e35ea