### PR TITLE
Remove battle shadows and tweak post-battle styling

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -22,7 +22,7 @@ body {
   height: 560px;
   position: relative;
   overflow: hidden;
-  background: rgba(0, 0, 0, 0.2);
+  background: none;
   border-radius: 8px;
   color: white;
   backdrop-filter: blur(4px);
@@ -89,10 +89,9 @@ body {
 img.fish-sprite {
   width: 220px;
   height: auto;
-  transition: transform 0.5s, filter 0.5s;
+  transition: transform 0.5s;
   cursor: pointer;
   margin-top: 8px;
-  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.5));
 }
 
 img.fish-sprite:hover {
@@ -206,44 +205,33 @@ img.fish-sprite:hover {
   opacity: 1;
 }
 
-.modal-content button {
+.modal-content .button {
   display: block;
-  border: none;
-  outline: none;
   width: 100%;
-  margin: 16px 0 0 0;
-  padding: 12px;
-  font-size: 16px;
-  cursor: pointer;
-  background: rgba(237, 241, 246, 0.8);
-  border-radius: 8px;
-  transition:
-    background 0.2s,
-    transform 0.2s,
-    box-shadow 0.2s;
-  backdrop-filter: blur(6px);
+  margin: 16px 0 0;
+  transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.modal-content button:hover {
+.modal-content .button:hover {
   transform: translateY(-2px);
 }
 
-.modal-content button:active {
+.modal-content .button:active {
   transform: translateY(1px);
 }
 
-.modal-content button.correct {
+.modal-content .button.correct {
   background: rgba(214, 243, 214, 0.8);
   border: 2px solid #00b600;
   color: #004d00;
 }
 
-.modal-content button.wrong {
+.modal-content .button.wrong {
   border: 2px solid #b60000;
   color: #b60000;
 }
 
-.modal-content button:disabled {
+.modal-content .button:disabled {
   opacity: 1;
 }
 
@@ -328,7 +316,6 @@ img.fish-sprite:hover {
 .sprite-wrapper {
   line-height: 0;
   transform: scale(0.8);
-  transform: scale(0.5);
   opacity: 0;
   margin: 20px 0;
   transition: transform 0.42s cubic-bezier(0.22, 1, 0.36, 1),

--- a/js/battle.js
+++ b/js/battle.js
@@ -262,7 +262,9 @@ function fetchQuestion() {
 
   content.innerHTML = `<div>${q.q}</div>
     <div id="timer" style="margin:10px 0; font-size:14px; color:#555;">Time left: ${timeLeft}s</div>
-    ${q.options.map((opt) => `<button>${opt}</button>`).join("")}`;
+    ${q.options
+      .map((opt) => `<button class="button">${opt}</button>`)
+      .join("")}`;
   modal.classList.add("show");
 
   timerId = setInterval(() => {


### PR DESCRIPTION
## Summary
- remove dark background and drop shadows from battle sprites
- scale victory sprite from 80% to full size and apply universal button style
- use global button style for quiz answers

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6352449b083298edaf2546c47b6c8