### PR TITLE
Add market nav item and refine battle UX

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -12,14 +12,16 @@ body {
 }
 
 #battle {
-  width: 560px;
-  height: 560px;
+  width: 100%;
+  max-width: var(--max-width);
+  aspect-ratio: 1;
   position: relative;
   animation: battleFadeIn 0.6s ease;
 }
 
 .battlefield {
-  height: 560px;
+  width: 100%;
+  height: 100%;
   position: relative;
   overflow: hidden;
   border-radius: 8px;
@@ -118,6 +120,8 @@ img.fish-sprite:hover {
   color: #ffffff;
   font-size: 48px;
   text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2);
+  padding: 16px 32px;
+  display: inline-block;
 }
 
 .winner-banner {
@@ -324,8 +328,7 @@ img.fish-sprite:hover {
 
 .sprite-wrapper {
   line-height: 0;
-  transform: scale(0.8);
-  transform: scale(0.5);
+  transform: scale(0);
   opacity: 0;
   margin: 20px 0;
   transition: transform 0.42s cubic-bezier(0.22, 1, 0.36, 1),

--- a/pages/battle.html
+++ b/pages/battle.html
@@ -31,7 +31,7 @@
         </div>
       </div>
 
-      <div id="intro" class="intro-overlay"><h1>Battle</h1></div>
+      <div id="intro" class="intro-overlay"><h1 class="apple-glass">Battle</h1></div>
     </div>
 
     <div id="modal">

--- a/pages/home.html
+++ b/pages/home.html
@@ -26,18 +26,16 @@
       </div>
 
       <!-- Bottom nav -->
-        <div class="apple-glass" id="nav">
-          <a class="nav-item" href="mission.html" id="mission-link">
-            <span class="emoji">🤿</span>
-            <span class="text">Mission</span>
-          </a>
-        </div>
-          <div class="apple-glass" id="nav">
-            <a class="nav-item" href="mission.html" id="mission-link">
-              <span class="emoji">🤿</span>
-              <span class="text">Mission</span>
-            </a>
-          </div>
+      <div class="apple-glass" id="nav">
+        <a class="nav-item" href="mission.html" id="mission-link">
+          <span class="emoji">🤿</span>
+          <span class="text">Mission</span>
+        </a>
+        <a class="nav-item" href="#" id="market-link">
+          <span class="emoji">🪸</span>
+          <span class="text">Market</span>
+        </a>
+      </div>
     </div>
 
     <script src="../js/userData.js"></script>


### PR DESCRIPTION
## Summary
- Stack home navigation horizontally and add coral "Market" entry
- Display battle intro text in an apple-glass container and cap battle layout to 425px
- Animate victory sprite from small to large for a livelier end screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a67aedeb24832984c7aa8d2c7b04f2