### PR TITLE
Refine navigation and battle visuals

### DIFF
--- a/css/battle.css
+++ b/css/battle.css
@@ -19,23 +19,14 @@ body {
   animation: battleFadeIn 0.6s ease;
 }
 
+/* Battlefield container */
 .battlefield {
-  .battlefield {
-    width: 100%;
-    height: 100%;
-    position: relative;
-    overflow: hidden;
-    color: white;
-  
-    /* ❌ remove these */
-    /* border-radius: 8px; */
-    /* backdrop-filter: blur(4px); */
-    /* border: 1px solid rgba(255, 255, 255, 0.4); */
-    /* box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1); */
-    
-    background: transparent; /* 👈 makes sure it stays clear */
-  }
-  
+  width: 100%;
+  height: 100%;
+  position: relative;
+  overflow: hidden;
+  color: white;
+  background: transparent; /* keep the arena clear */
 }
 
 .creature {
@@ -46,13 +37,13 @@ body {
 }
 
 #player {
-  bottom: 30px;
+  bottom: 60px; /* push player's creature further down */
   left: 40px;
   animation: slideInLeft 1s ease-out forwards;
 }
 
 #enemy {
-  top: 30px;
+  top: 60px; /* push enemy's creature further up */
   right: 40px;
   animation: slideInRight 1s ease-out forwards;
 }
@@ -64,9 +55,6 @@ body {
   text-align: left;
   font-size: 16px;
   line-height: 1.8em;
-  border-radius: 10px;
-  backdrop-filter: blur(4px);
-  border: 1px solid rgba(255, 255, 255, 0.3);
   text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2);
   margin-bottom: 8px;
 }
@@ -196,13 +184,11 @@ img.fish-sprite:hover {
 }
 
 .modal-content {
-  background: #fff;
   padding: 32px;
   width: 350px;
   text-align: center;
   font-size: 18px;
   line-height: 1.5;
-  border-radius: 8px;
   transform: scale(0.8);
   opacity: 0;
   transition:

--- a/css/styles.css
+++ b/css/styles.css
@@ -158,6 +158,8 @@ body.mission #creature-container {
 /* Navigation */
 .nav-row {
   display: flex;
+  flex-direction: row; /* ensure nav items line up horizontally */
+  justify-content: center; /* keep nav centered at the bottom */
   width: 100%;
   gap: 16px; /* spacing between the two blocks */
 }

--- a/pages/battle.html
+++ b/pages/battle.html
@@ -13,7 +13,7 @@
     <div id="battle">
       <div class="battlefield" id="battlefield">
         <div id="enemy" class="creature">
-          <div class="name-hp-box">
+          <div class="name-hp-box apple-glass">
             <div id="enemy-name">Octomurk</div>
             <div class="hp-bar"><div id="enemy-hp" class="hp-fill"></div></div>
             <div id="enemy-stats" class="stats"></div>
@@ -22,7 +22,7 @@
         </div>
 
         <div id="player" class="creature">
-          <div class="name-hp-box">
+          <div class="name-hp-box apple-glass">
             <div id="player-name">Shellfin</div>
             <div class="hp-bar"><div id="player-hp" class="hp-fill"></div></div>
             <div id="player-stats" class="stats"></div>
@@ -35,7 +35,7 @@
     </div>
 
     <div id="modal">
-      <div class="modal-content" id="modal-content"></div>
+      <div class="modal-content apple-glass" id="modal-content"></div>
     </div>
 
     <script src="../js/userData.js"></script>


### PR DESCRIPTION
## Summary
- Ensure home page bottom navigation lays out horizontally with consistent 16px spacing.
- Apply reusable Apple glass styling to battle UI elements and increase spacing between combatants for a more Pokémon-like layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a681376db88329ac677fdb6708d3cb