### PR TITLE
Display creature stats on home page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -115,12 +115,42 @@ body.mission #app {
 
 /* Creature */
 #creature-info {
-  text-align: center;
-  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
   margin-bottom: 8px;
-  font-size: 48px;
+  width: 100%;
+  padding: 12px 20px;
+  box-sizing: border-box;
+}
+
+#creature-name {
+  font-size: 24px;
   text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2);
 }
+
+.hp-bar {
+  height: 8px;
+  width: 100%;
+  border: 1px solid #fff;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.hp-fill {
+  background-image: linear-gradient(90deg, orange, yellow);
+  height: 100%;
+  width: 100%;
+  border-radius: 8px;
+}
+
+.stats {
+  margin-top: 4px;
+  font-size: 14px;
+  text-shadow: 4px 4px 4px rgba(0, 0, 0, 0.2);
+}
+
 #creature-container {
   width: 180px;
   height: 180px;

--- a/pages/home.html
+++ b/pages/home.html
@@ -20,7 +20,11 @@
       </div>
 
       <!-- Creature -->
-      <div id="creature-info"></div>
+      <div id="creature-info" class="apple-glass">
+        <div id="creature-name"></div>
+        <div class="hp-bar"><div id="creature-hp" class="hp-fill"></div></div>
+        <div id="creature-stats" class="stats"></div>
+      </div>
       <div id="creature-container">
         <img src="../images/shellfin.png" alt="Creature Sprite" />
       </div>
@@ -61,8 +65,13 @@
           `🐚 ${user.seashells} Seashells`;
         if (user.creatures && user.creatures.length > 0) {
           const c = user.creatures[0];
-          const infoEl = document.getElementById("creature-info");
-          if (infoEl) infoEl.textContent = c.name;
+          const nameEl = document.getElementById("creature-name");
+          if (nameEl) nameEl.textContent = c.name;
+          const hpEl = document.getElementById("creature-hp");
+          if (hpEl) hpEl.style.width = "100%";
+          const statsEl = document.getElementById("creature-stats");
+          if (statsEl)
+            statsEl.textContent = `HP: ${c.hp}/${c.hp} | ATK: ${c.attack}`;
           const imgEl = document.querySelector("#creature-container img");
           if (imgEl && c.sprite && c.sprite.normal)
             imgEl.src = c.sprite.normal;


### PR DESCRIPTION
## Summary
- show creature name within apple-glass card
- add health bar and HP/ATK stats mirroring battle page
- style creature card and health bar in main stylesheet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a683ffd3a883298c060a6b003bbbcd