### PR TITLE
Reset battle state on page restore

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -44,6 +44,12 @@ let questions = [];
 let currentMission = null;
 let isGameOver = false;
 
+window.addEventListener("pageshow", () => {
+  isGameOver = false;
+  const endScreen = document.querySelector(".end-screen");
+  if (endScreen) endScreen.remove();
+});
+
 // ====== Helpers ======
 function updateHP() {
   const pPct = (player.hp / player.maxHp) * 100;


### PR DESCRIPTION
## Summary
- Reset `isGameOver` flag when the battle page is shown again
- Remove any stale `.end-screen` overlay on page restore

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a68815b1e48329ba6afd5af4b07084