### PR TITLE
Add island map test page

### DIFF
--- a/pages/test.html
+++ b/pages/test.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Map Test</title>
+    <link rel="stylesheet" href="../css/styles.css" />
+    <style>
+      html, body, #app {
+        height: 100%;
+        margin: 0;
+      }
+      #map-iframe {
+        border: 0;
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <iframe
+        id="map-iframe"
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d7840.873775339239!2d-151.73932645!3d-16.50041245!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x76f94e92d3293c87%3A0xc5fc8e4dafbd2f0e!2sBora%20Bora!5e0!3m2!1sen!2sus!4v1676604442731!5m2!1sen!2sus"
+        allowfullscreen=""
+        loading="lazy"
+        referrerpolicy="no-referrer-when-downgrade"></iframe>
+    </div>
+    <script src="../js/bubbles.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace Google Maps API usage with embedded Bora Bora map to avoid API key

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a725f1cf248329981dd46dcc10c20e