### PR TITLE
Add ocean-themed map test page

### DIFF
--- a/pages/test2.html
+++ b/pages/test2.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Ocean Map Test</title>
+    <link rel="stylesheet" href="../css/styles.css" />
+    <style>
+      html, body, #app, #map {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+      }
+      #map {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <div id="map"></div>
+    </div>
+    <script>
+      const mapStyle = [
+        { elementType: "geometry", stylers: [{ color: "#0d3a6b" }] },
+        { elementType: "labels.text.fill", stylers: [{ color: "#ffffff" }] },
+        { elementType: "labels.text.stroke", stylers: [{ color: "#0a223d" }] },
+        { featureType: "water", elementType: "geometry", stylers: [{ color: "#1e88e5" }] },
+        { featureType: "landscape", elementType: "geometry", stylers: [{ color: "#0d3a6b" }] },
+        { featureType: "road", elementType: "geometry", stylers: [{ color: "#115e92" }] },
+        { featureType: "road.highway", elementType: "geometry", stylers: [{ color: "#0b497a" }] },
+        { featureType: "road", elementType: "labels.text.fill", stylers: [{ color: "#ffffff" }] },
+        { featureType: "poi", elementType: "geometry", stylers: [{ color: "#0d3a6b" }] }
+      ];
+
+      function initMap() {
+        const map = new google.maps.Map(document.getElementById("map"), {
+          center: { lat: 0, lng: 0 },
+          zoom: 15,
+          styles: mapStyle,
+          disableDefaultUI: true,
+        });
+      }
+    </script>
+    <script async defer src="https://maps.googleapis.com/maps/api/js?key=YOUR_API_KEY&callback=initMap"></script>
+    <script src="../js/bubbles.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add test2.html with full-screen Google Map styled in blue to match ocean theme

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7306d842083298ca6bc139e9ce322