### PR TITLE
Set home page HP bar to half width and expand clickable areas

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -79,6 +79,7 @@ body.mission #app {
   gap: 8px;
   padding: 12px 20px;
   width: 100%;
+  text-decoration: none;
 }
 
 .currency span {
@@ -137,6 +138,10 @@ body.mission #app {
   border: 1px solid #fff;
   border-radius: 8px;
   overflow: hidden;
+}
+
+body.home .hp-bar {
+  width: 50%;
 }
 
 .hp-fill {

--- a/pages/home.html
+++ b/pages/home.html
@@ -11,12 +11,12 @@
     <div id="app">
       <!-- Top currency -->
       <div id="currency-container">
-        <div class="apple-glass currency">
+        <a class="apple-glass currency" href="#">
           <span class="emoji" id="streak">🏄 0 Day Streak</span>
-        </div>
-        <div class="apple-glass currency">
+        </a>
+        <a class="apple-glass currency" href="#">
           <span class="emoji" id="seashells">🐚 0 Seashells</span>
-        </div>
+        </a>
       </div>
 
       <!-- Creature -->
@@ -31,18 +31,14 @@
 
       <!-- Bottom nav -->
       <div class="nav-row">
-        <div class="apple-glass nav-block">
-          <a class="nav-item" href="mission.html" id="mission-link">
-            <span class="emoji">🤿</span>
-            <span class="text">Mission</span>
-          </a>
-        </div>
-        <div class="apple-glass nav-block">
-          <a class="nav-item" href="#" id="market-link">
-            <span class="emoji">🪸</span>
-            <span class="text">Market</span>
-          </a>
-        </div>
+        <a class="apple-glass nav-block nav-item" href="mission.html" id="mission-link">
+          <span class="emoji">🤿</span>
+          <span class="text">Mission</span>
+        </a>
+        <a class="apple-glass nav-block nav-item" href="#" id="market-link">
+          <span class="emoji">🪸</span>
+          <span class="text">Market</span>
+        </a>
       </div>
       
       
@@ -67,8 +63,6 @@
           const c = user.creatures[0];
           const nameEl = document.getElementById("creature-name");
           if (nameEl) nameEl.textContent = c.name;
-          const hpEl = document.getElementById("creature-hp");
-          if (hpEl) hpEl.style.width = "100%";
           const statsEl = document.getElementById("creature-stats");
           if (statsEl)
             statsEl.textContent = `HP: ${c.hp}/${c.hp} | ATK: ${c.attack}`;


### PR DESCRIPTION
## Summary
- Resize home page HP bar container to half width so fill spans only 50%
- Convert currency and nav blocks into full-width links for easier clicking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76347e5908329a75ee2479b12b0d9