### PR TITLE
feat: random mission spawning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -181,6 +181,27 @@ body.mission #creature-container {
   height: auto;
 }
 
+/* Mission spawn bubble */
+.mission-bubble {
+  width: 130px;
+  height: 130px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: float 3s ease-in-out infinite;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+}
+
+.mission-bubble img {
+  width: 130px;
+  height: auto;
+}
+
 @keyframes float {
   0%,
   100% {

--- a/js/battle.js
+++ b/js/battle.js
@@ -342,6 +342,9 @@ async function initGame() {
       enemy.maxHp = e.hp;
       enemy.move.power = e.attack;
       if (e.sprite) enemy.sprite = e.sprite;
+    } else if (currentMission && currentMission.sprite) {
+      enemy.name = currentMission.name;
+      enemy.sprite = currentMission.sprite;
     }
   } catch (err) {
     console.error("Failed to load missions:", err);
@@ -359,6 +362,12 @@ async function initGame() {
   const playerSpriteEl = document.querySelector("#player .fish-sprite");
   if (playerSpriteEl && playerCreature.sprite && playerCreature.sprite.battle) {
     playerSpriteEl.src = playerCreature.sprite.battle;
+  }
+
+  // Auto-win if mission has no enemy (e.g., Treasure)
+  if (!currentMission || !currentMission.enemy) {
+    setTimeout(() => endBattle(player), 1000);
+    return;
   }
 
   // Initial HP state

--- a/js/missionSpawner.js
+++ b/js/missionSpawner.js
@@ -1,0 +1,64 @@
+// missionSpawner.js
+// Spawns a random mission every 30 seconds.
+
+(async function () {
+  document.addEventListener("DOMContentLoaded", async () => {
+    const user = getCurrentUser();
+    if (!user) {
+      window.location.href = "index.html";
+      return;
+    }
+
+    let missions = [];
+    try {
+      const res = await fetch("../data/missions.json");
+      const data = await res.json();
+      if (Array.isArray(data.missions)) missions = data.missions;
+    } catch (err) {
+      console.error("Failed to load missions:", err);
+      return;
+    }
+
+    function pickMission() {
+      const roll = Math.floor(Math.random() * 16) + 1; // 1-16
+      return missions.find((m) =>
+        String(m.spawn)
+          .split(",")
+          .map((n) => parseInt(n.trim(), 10))
+          .includes(roll),
+      );
+    }
+
+    function spawnMission() {
+      const app = document.getElementById("app");
+      if (!app) return;
+
+      const existing = document.querySelector(".mission-bubble");
+      if (existing) existing.remove();
+
+      const mission = pickMission();
+      if (!mission) return;
+
+      const bubble = document.createElement("div");
+      bubble.className = "apple-glass mission-bubble";
+
+      const img = document.createElement("img");
+      const sprite = mission.enemy ? mission.enemy.sprite : mission.sprite;
+      img.src = sprite;
+      img.alt = mission.name;
+      bubble.appendChild(img);
+
+      bubble.addEventListener("click", () => {
+        sessionStorage.setItem("currentMission", JSON.stringify(mission));
+        const idx = missions.indexOf(mission);
+        sessionStorage.setItem("currentMissionIndex", String(idx));
+        window.location.href = "battle.html";
+      });
+
+      app.appendChild(bubble);
+    }
+
+    spawnMission();
+    setInterval(spawnMission, 30000);
+  });
+})();

--- a/pages/mission.html
+++ b/pages/mission.html
@@ -8,66 +8,10 @@
   <body class="mission">
     <!-- Close X -->
     <a id="close" href="home.html">✕</a>
-    <div id="app">
-      <!-- Creature -->
-      <div id="creature-container">
-        <img src="../images/octomurk.png" alt="Creature Sprite" />
-      </div>
-
-      <!-- Mission box -->
-      <div class="apple-glass" id="mission">
-        <h1 id="mission-title"></h1>
-        <p id="mission-desc"></p>
-        <div class="rewards" id="mission-reward"></div>
-        <a href="battle.html" class="button" id="accept-mission">Accept Mission</a>
-      </div>
-    </div>
+    <div id="app"></div>
 
     <script src="../js/userData.js"></script>
-    <script>
-      document.addEventListener("DOMContentLoaded", async () => {
-        const user = getCurrentUser();
-        if (!user) {
-          window.location.href = "index.html";
-          return;
-        }
-        try {
-          const res = await fetch("../data/missions.json");
-          const data = await res.json();
-          if (Array.isArray(data.missions) && data.missions.length > 0) {
-            let missionIndex = 0;
-            if (Array.isArray(user.missionsCompleted)) {
-              const idx = user.missionsCompleted.findIndex(
-                (m) => !m.completed,
-              );
-              if (idx !== -1) missionIndex = idx;
-            }
-              const mission = data.missions[missionIndex];
-              sessionStorage.setItem(
-                "currentMission",
-                JSON.stringify(mission),
-              );
-              sessionStorage.setItem(
-                "currentMissionIndex",
-                String(missionIndex),
-              );
-              document.getElementById("mission-title").textContent = mission.name;
-              document.getElementById("mission-desc").textContent =
-                mission.description;
-              document.getElementById(
-                "mission-reward",
-              ).textContent = `🐚 ${mission.reward} Seashells`;
-              const imgEl = document.querySelector(
-                "#creature-container img",
-              );
-              if (imgEl && mission.enemy && mission.enemy.sprite)
-                imgEl.src = mission.enemy.sprite;
-            }
-          } catch (err) {
-            console.error("Failed to load missions:", err);
-          }
-        });
-    </script>
+    <script src="../js/missionSpawner.js"></script>
     <script src="../js/bubbles.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplify missions page to a blank canvas that spawns missions every 30 seconds
- Add mission spawner script to pick random missions and start battles
- Auto-resolve treasure missions in battle logic and style floating mission bubbles

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a771c5bae883298d74111e1843a811