### PR TITLE
feat: random mission spawning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -181,6 +181,40 @@ body.mission #creature-container {
   height: auto;
 }
 
+/* Mission spawn bubble */
+.mission-bubble {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: float 3s ease-in-out infinite;
+  position: absolute;
+  cursor: pointer;
+}
+
+.mission-bubble.spawn {
+  animation: pop-in 0.3s ease-out forwards,
+    float 3s ease-in-out infinite 0.3s;
+}
+
+.mission-bubble img {
+  width: calc(100% - 48px);
+  height: calc(100% - 48px);
+  padding: 24px;
+  object-fit: contain;
+}
+
+@keyframes pop-in {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
 @keyframes float {
   0%,
   100% {

--- a/js/battle.js
+++ b/js/battle.js
@@ -128,6 +128,7 @@ function endBattle(winner) {
   else isGameOver = true;
 
   const LINGER = typeof LINGER_BOTH_MS !== "undefined" ? LINGER_BOTH_MS : 1200;
+  const isTreasure = currentMission && currentMission.name === "Treasure";
 
   // Close any open modal
   const modal = document.getElementById("modal");
@@ -138,7 +139,7 @@ function endBattle(winner) {
   );
   const winnerIsPlayer = winner === player;
 
-  // Phase A: linger briefly with both creatures visible
+  // Phase A: linger briefly with both creatures visible (skip for treasure)
   setTimeout(() => {
     const battleRoot = document.getElementById("battle");
     const battlefield = document.getElementById("battlefield");
@@ -156,7 +157,11 @@ function endBattle(winner) {
     // Banner
     const banner = document.createElement("h1");
     banner.className = "end-banner";
-    banner.textContent = winnerIsPlayer ? "Victory!" : "Defeat";
+    banner.textContent = isTreasure
+      ? "Treasure"
+      : winnerIsPlayer
+        ? "Victory!"
+        : "Defeat";
 
     // Sprite wrapper
     const spriteWrapper = document.createElement("div");
@@ -166,10 +171,16 @@ function endBattle(winner) {
     const originalSprite = winnerEl?.querySelector(".fish-sprite");
     const sprite = document.createElement("img");
     sprite.className = "end-sprite";
-    sprite.alt = winnerIsPlayer ? player.name : enemy.name;
-    sprite.src = winnerIsPlayer
-      ? PLAYER_VICTORY_SRC
-      : originalSprite?.getAttribute("src") || "";
+    sprite.alt = isTreasure
+      ? "Treasure"
+      : winnerIsPlayer
+        ? player.name
+        : enemy.name;
+    sprite.src = isTreasure
+      ? currentMission?.sprite || "../images/treasure.png"
+      : winnerIsPlayer
+        ? PLAYER_VICTORY_SRC
+        : originalSprite?.getAttribute("src") || "";
 
     spriteWrapper.appendChild(sprite);
 
@@ -220,7 +231,7 @@ function endBattle(winner) {
     requestAnimationFrame(() => {
       victoryBox.classList.add("show");
     });
-  }, LINGER);
+  }, isTreasure ? 0 : LINGER);
 }
 
 // ====== Turn Flow ======
@@ -342,9 +353,18 @@ async function initGame() {
       enemy.maxHp = e.hp;
       enemy.move.power = e.attack;
       if (e.sprite) enemy.sprite = e.sprite;
+    } else if (currentMission && currentMission.sprite) {
+      enemy.name = currentMission.name;
+      enemy.sprite = currentMission.sprite;
     }
   } catch (err) {
     console.error("Failed to load missions:", err);
+  }
+
+  // If mission has no enemy (e.g., Treasure), show reward immediately
+  if (!currentMission || !currentMission.enemy) {
+    endBattle(player);
+    return;
   }
 
   const playerNameEl = document.getElementById("player-name");

--- a/js/missionSpawner.js
+++ b/js/missionSpawner.js
@@ -1,0 +1,72 @@
+// missionSpawner.js
+// Spawns a random mission first after 5s, then every 30s.
+
+(async function () {
+  document.addEventListener("DOMContentLoaded", async () => {
+    const user = getCurrentUser();
+    if (!user) {
+      window.location.href = "index.html";
+      return;
+    }
+
+    let missions = [];
+    try {
+      const res = await fetch("../data/missions.json");
+      const data = await res.json();
+      if (Array.isArray(data.missions)) missions = data.missions;
+    } catch (err) {
+      console.error("Failed to load missions:", err);
+      return;
+    }
+
+    function pickMission() {
+      const roll = Math.floor(Math.random() * 16) + 1; // 1-16
+      return missions.find((m) =>
+        String(m.spawn)
+          .split(",")
+          .map((n) => parseInt(n.trim(), 10))
+          .includes(roll),
+      );
+    }
+
+    function spawnMission() {
+      const app = document.getElementById("app");
+      if (!app) return;
+
+      const bubbles = app.querySelectorAll(".mission-bubble");
+      if (bubbles.length >= 3) bubbles[0].remove();
+
+      const mission = pickMission();
+      if (!mission) return;
+
+      const bubble = document.createElement("div");
+      bubble.className = "apple-glass mission-bubble spawn";
+
+      const size = 120;
+      const maxLeft = app.clientWidth - size;
+      const maxTop = app.clientHeight - size;
+      bubble.style.left = `${Math.random() * maxLeft}px`;
+      bubble.style.top = `${Math.random() * maxTop}px`;
+
+      const img = document.createElement("img");
+      const sprite = mission.enemy ? mission.enemy.sprite : mission.sprite;
+      img.src = sprite;
+      img.alt = mission.name;
+      bubble.appendChild(img);
+
+      bubble.addEventListener("click", () => {
+        sessionStorage.setItem("currentMission", JSON.stringify(mission));
+        const idx = missions.indexOf(mission);
+        sessionStorage.setItem("currentMissionIndex", String(idx));
+        window.location.href = "battle.html";
+      });
+
+      app.appendChild(bubble);
+    }
+
+    setTimeout(() => {
+      spawnMission();
+      setInterval(spawnMission, 30000);
+    }, 5000);
+  });
+})();

--- a/pages/mission.html
+++ b/pages/mission.html
@@ -8,66 +8,10 @@
   <body class="mission">
     <!-- Close X -->
     <a id="close" href="home.html">✕</a>
-    <div id="app">
-      <!-- Creature -->
-      <div id="creature-container">
-        <img src="../images/octomurk.png" alt="Creature Sprite" />
-      </div>
-
-      <!-- Mission box -->
-      <div class="apple-glass" id="mission">
-        <h1 id="mission-title"></h1>
-        <p id="mission-desc"></p>
-        <div class="rewards" id="mission-reward"></div>
-        <a href="battle.html" class="button" id="accept-mission">Accept Mission</a>
-      </div>
-    </div>
+    <div id="app"></div>
 
     <script src="../js/userData.js"></script>
-    <script>
-      document.addEventListener("DOMContentLoaded", async () => {
-        const user = getCurrentUser();
-        if (!user) {
-          window.location.href = "index.html";
-          return;
-        }
-        try {
-          const res = await fetch("../data/missions.json");
-          const data = await res.json();
-          if (Array.isArray(data.missions) && data.missions.length > 0) {
-            let missionIndex = 0;
-            if (Array.isArray(user.missionsCompleted)) {
-              const idx = user.missionsCompleted.findIndex(
-                (m) => !m.completed,
-              );
-              if (idx !== -1) missionIndex = idx;
-            }
-              const mission = data.missions[missionIndex];
-              sessionStorage.setItem(
-                "currentMission",
-                JSON.stringify(mission),
-              );
-              sessionStorage.setItem(
-                "currentMissionIndex",
-                String(missionIndex),
-              );
-              document.getElementById("mission-title").textContent = mission.name;
-              document.getElementById("mission-desc").textContent =
-                mission.description;
-              document.getElementById(
-                "mission-reward",
-              ).textContent = `🐚 ${mission.reward} Seashells`;
-              const imgEl = document.querySelector(
-                "#creature-container img",
-              );
-              if (imgEl && mission.enemy && mission.enemy.sprite)
-                imgEl.src = mission.enemy.sprite;
-            }
-          } catch (err) {
-            console.error("Failed to load missions:", err);
-          }
-        });
-    </script>
+    <script src="../js/missionSpawner.js"></script>
     <script src="../js/bubbles.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Spawn missions starting 5s after load, then every 30s, capping at three active bubbles
- Pad mission sprites 24px for uniform size inside floating glass bubbles
- Skip battles for Treasure missions and show immediate treasure reward screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a771c5bae883298d74111e1843a811