### PR TITLE
Fix mission page spawning logic

### DIFF
--- a/js/missionSpawner.js
+++ b/js/missionSpawner.js
@@ -1,7 +1,6 @@
 // missionSpawner.js
 // Random mission spawning with persistence across reloads.
 // Spawns a random mission first after 5s, then every 30s.
-// Spawns a random mission every 30 seconds.
 
 (async function () {
   document.addEventListener("DOMContentLoaded", async () => {
@@ -15,7 +14,7 @@
     try {
       const res = await fetch("../data/missions.json");
       const data = await res.json();
-      if (Array.isArray(data.missions)) missions = data.missions;
+      missions = Array.isArray(data.missions) ? data.missions : [];
     } catch (err) {
       console.error("Failed to load missions:", err);
       return;
@@ -43,7 +42,7 @@
       );
     }
 
-    function createBubble(mission, idx, left, top, id, animate) {
+    function createBubble(mission, index, left, top, id, animate) {
       const app = document.getElementById("app");
       if (!app) return;
 
@@ -53,27 +52,6 @@
       bubble.style.top = `${top}px`;
       bubble.dataset.id = String(id);
 
-    function spawnMission() {
-      const app = document.getElementById("app");
-      if (!app) return;
-
-      const bubbles = app.querySelectorAll(".mission-bubble");
-      if (bubbles.length >= 3) bubbles[0].remove();
-      const existing = document.querySelector(".mission-bubble");
-      if (existing) existing.remove();
-
-      const mission = pickMission();
-      if (!mission) return;
-
-      const bubble = document.createElement("div");
-      bubble.className = "apple-glass mission-bubble spawn";
-
-      const size = 120;
-      const maxLeft = app.clientWidth - size;
-      const maxTop = app.clientHeight - size;
-      bubble.style.left = `${Math.random() * maxLeft}px`;
-      bubble.style.top = `${Math.random() * maxTop}px`;
-      bubble.className = "apple-glass mission-bubble";
       const img = document.createElement("img");
       const sprite = mission.enemy ? mission.enemy.sprite : mission.sprite;
       img.src = sprite;
@@ -82,11 +60,9 @@
 
       bubble.addEventListener("click", () => {
         sessionStorage.setItem("currentMission", JSON.stringify(mission));
-        sessionStorage.setItem("currentMissionIndex", String(idx));
+        sessionStorage.setItem("currentMissionIndex", String(index));
         activeMissions = activeMissions.filter((m) => m.id !== id);
         saveActive();
-        const idx = missions.indexOf(mission);
-        sessionStorage.setItem("currentMissionIndex", String(idx));
         window.location.href = "battle.html";
       });
 
@@ -113,7 +89,7 @@
       const mission = pickMission();
       if (!mission) return;
 
-      const idx = missions.indexOf(mission);
+      const index = missions.indexOf(mission);
       const size = 120;
       const maxLeft = app.clientWidth - size;
       const maxTop = app.clientHeight - size;
@@ -121,8 +97,8 @@
       const top = Math.random() * maxTop;
       const id = Date.now() + Math.random();
 
-      createBubble(mission, idx, left, top, id, true);
-      activeMissions.push({ id, index: idx, left, top });
+      createBubble(mission, index, left, top, id, true);
+      activeMissions.push({ id, index, left, top });
       saveActive();
       sessionStorage.setItem("lastSpawnTime", String(Date.now()));
     }
@@ -141,11 +117,3 @@
   });
 })();
 
-    setTimeout(() => {
-      spawnMission();
-      setInterval(spawnMission, 30000);
-    }, 5000);
-    spawnMission();
-    setInterval(spawnMission, 30000);
-  });
-})();


### PR DESCRIPTION
## Summary
- refactor mission spawner to remove duplicate logic and correctly spawn missions

## Testing
- `node --check js/missionSpawner.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a50f0e44832996d1c1f89fb2933d