### PR TITLE
Fix health tracking and seashell reset on defeat

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -53,10 +53,10 @@ window.addEventListener("pageshow", () => {
   if (endScreen) endScreen.remove();
 });
 
-function persistPlayerHp() {
+function persistPlayerHp(extra = {}) {
   if (user && user.creatures && user.creatures[0]) {
     user.creatures[0].currentHp = player.hp;
-    updateCurrentUser({ creatures: user.creatures });
+    updateCurrentUser({ creatures: user.creatures, ...extra });
   }
 }
 
@@ -268,11 +268,7 @@ function enemyTurn() {
   animateAttack(enemy);
   setTimeout(() => {
     player.hp = Math.max(0, player.hp - enemy.move.power);
-    persistPlayerHp();
-    if (user && user.creatures && user.creatures[0]) {
-      user.creatures[0].currentHp = player.hp;
-      updateCurrentUser({ creatures: user.creatures });
-    }
+    persistPlayerHp(player.hp <= 0 ? { seashells: 0 } : undefined);
     animateHP("player", () => {
       if (player.hp <= 0) {
         endBattle(enemy);

--- a/pages/home.html
+++ b/pages/home.html
@@ -57,29 +57,37 @@
         }
         document.getElementById("streak").textContent =
           `🏄 ${signInStreak} Day Streak`;
-        document.getElementById("seashells").textContent =
-          `🐚 ${user.seashells} Seashells`;
+
+        let seashells = user.seashells || 0;
+        let currentHp = null;
         if (user.creatures && user.creatures.length > 0) {
           const c = user.creatures[0];
           const nameEl = document.getElementById("creature-name");
           if (nameEl) nameEl.textContent = c.name;
           const hpEl = document.getElementById("creature-hp");
-          if (hpEl) hpEl.style.width = "100%";
+          currentHp = typeof c.currentHp === "number" ? c.currentHp : c.hp;
+          if (hpEl) hpEl.style.width = (currentHp / c.hp) * 100 + "%";
           const statsEl = document.getElementById("creature-stats");
           if (statsEl)
-            statsEl.textContent = `HP: ${c.hp}/${c.hp} | ATK: ${c.attack}`;
+            statsEl.textContent = `HP: ${currentHp}/${c.hp} | ATK: ${c.attack}`;
           const imgEl = document.querySelector("#creature-container img");
           if (imgEl && c.sprite && c.sprite.normal)
             imgEl.src = c.sprite.normal;
         }
+        if (currentHp !== null && currentHp <= 0 && seashells !== 0) {
+          seashells = 0;
+          updateCurrentUser({ seashells });
+        }
+        document.getElementById("seashells").textContent =
+          `🐚 ${seashells} Seashells`;
 
-      const missionLink = document.getElementById("mission-link");
-      if (missionLink) {
-        missionLink.addEventListener("click", (e) => {
-          e.preventDefault();
-          window.location.href = "mission.html";
-        });
-      }
+        const missionLink = document.getElementById("mission-link");
+        if (missionLink) {
+          missionLink.addEventListener("click", (e) => {
+            e.preventDefault();
+            window.location.href = "mission.html";
+          });
+        }
       } else {
         window.location.href = "index.html";
       }


### PR DESCRIPTION
## Summary
- Display creature's current HP on home screen
- Reset seashells to 0 when a player is defeated
- Allow HP persistence helper to accept extra fields

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/reefrangers/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a7a7c909e883298a1dfab2457c3e44