### PR TITLE
fix: ensure non-combat missions show reward screens

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -134,6 +134,8 @@ function animateAttack(attacker) {
 // Phase B: show ONLY winner, centered with "Winner" banner; swap sprite if player wins
 function endBattle(winner) {
   if (document.querySelector(".end-screen")) return;
+  const intro = document.getElementById("intro");
+  if (intro) intro.remove();
   const isTreasure = currentMission && currentMission.name === "Treasure";
   const isPotion = currentMission && currentMission.name === "Potion";
   if (player.hp > 0 && !isPotion) {
@@ -361,16 +363,7 @@ function fetchQuestion() {
 
 // ====== Delayed Init Flow ======
 async function initGame() {
-  // Load questions
-  try {
-    const res = await fetch("../data/questions.json");
-    const data = await res.json();
-    if (Array.isArray(data)) questions = data;
-  } catch (err) {
-    console.error("Failed to load questions:", err);
-  }
-
-  // Load mission data
+  // Load mission data first so we can skip combat missions early
   try {
     const stored = sessionStorage.getItem("currentMission");
     if (stored) {
@@ -402,6 +395,15 @@ async function initGame() {
   if (!currentMission || !currentMission.enemy) {
     endBattle(player);
     return;
+  }
+
+  // Load questions only for combat missions
+  try {
+    const res = await fetch("../data/questions.json");
+    const data = await res.json();
+    if (Array.isArray(data)) questions = data;
+  } catch (err) {
+    console.error("Failed to load questions:", err);
   }
 
   const playerNameEl = document.getElementById("player-name");


### PR DESCRIPTION
## Summary
- load mission data before question fetches in battle setup
- end non-combat missions immediately without loading quiz data
- remove intro overlay so treasure and potion rewards are visible

## Testing
- `node --check js/battle.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8b334e5208329843ed8a58f728823