### PR TITLE
Skip battle for potion and treasure missions

### DIFF
--- a/js/battle.js
+++ b/js/battle.js
@@ -363,6 +363,9 @@ function fetchQuestion() {
 
 // ====== Delayed Init Flow ======
 async function initGame() {
+  const params = new URLSearchParams(window.location.search);
+  const forceEnd = params.has("end");
+
   // Load mission data first so we can skip combat missions early
   try {
     const stored = sessionStorage.getItem("currentMission");
@@ -391,8 +394,9 @@ async function initGame() {
     console.error("Failed to load missions:", err);
   }
 
-  // If mission has no enemy (e.g., Treasure or Potion), handle immediately
-  if (!currentMission || !currentMission.enemy) {
+  // If mission has no enemy (e.g., Potion or Treasure) or we explicitly
+  // request to skip combat, immediately show the end screen.
+  if (forceEnd || !currentMission || !currentMission.enemy) {
     endBattle(player);
     return;
   }

--- a/js/missionSpawner.js
+++ b/js/missionSpawner.js
@@ -77,11 +77,20 @@
           bubble.remove();
           return;
         }
+
+        // Persist the mission so battle.html knows what was selected
         sessionStorage.setItem("currentMission", JSON.stringify(mission));
         sessionStorage.setItem("currentMissionIndex", String(index));
+
+        // Remove from active list and persist
         activeMissions = activeMissions.filter((m) => m.id !== id);
         saveActive();
-        window.location.href = "battle.html";
+
+        // Non-combat missions (e.g., Potion or Treasure) should skip directly to
+        // the battle end screen. We signal this via a query param so battle.js
+        // can immediately show the result without attempting a fight.
+        const target = mission.enemy ? "battle.html" : "battle.html?end=1";
+        window.location.href = target;
       });
 
       app.appendChild(bubble);


### PR DESCRIPTION
## Summary
- Detect potion/treasure missions in mission spawner and redirect straight to end screen
- Allow battle page to honor explicit `?end` flag for non-combat missions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ba66031c8329b92b29959a17002e